### PR TITLE
remove branch from links to meeko readthedocs

### DIFF
--- a/docs/source/docking_basic.rst
+++ b/docs/source/docking_basic.rst
@@ -10,7 +10,7 @@ System and software requirements
 
 This is a command-line tutorial for a basic docking experiment with AutoDock-Vina. It can be done on macOS, Linux, and Windows Subsystem for Linux (WSL). 
 
-This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io/en/release-doc>`_.
+This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io>`_.
 
 The **input and expected output files** can be found here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/basic_docking>`_.
 

--- a/docs/source/docking_flexible.rst
+++ b/docs/source/docking_flexible.rst
@@ -10,7 +10,7 @@ System and software requirements
 
 This is a command-line tutorial for a flexible docking experiment with AutoDock-Vina. It can be done on macOS, Linux, and Windows Subsystem for Linux (WSL). 
 
-This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io/en/release-doc>`_.
+This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io>`_.
 
 The **input and expected output files** can be found here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/flexible_docking>`_.
 

--- a/docs/source/docking_hydrated.rst
+++ b/docs/source/docking_hydrated.rst
@@ -18,7 +18,7 @@ System and software requirements
 
 This is a command-line tutorial for a hydrated docking experiment with AutoDock-Vina. It can be done on macOS, Linux, and Windows Subsystem for Linux (WSL). 
 
-This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io/en/release-doc>`_.
+This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io>`_.
 
 The **input and expected output files** can be found here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/hydrated_docking>`_. 
 

--- a/docs/source/docking_in_batch.rst
+++ b/docs/source/docking_in_batch.rst
@@ -3,16 +3,16 @@
 Docking in batch mode
 ================
 
-Docking in batch mode (running the docking calculation with multiple ligands, one by one, one for a single run) is possible with AutoDock Vina. This is useful when you want to perform virtual screening of a large number of ligands against a target protein. The following sections describe how to do this using the command line. For possible ways of doing this with the Python API, see :ref:`docking_python`. 
+Docking many ligands sequentially, one after the other, is possible with AutoDock Vina. This is useful to perform virtual screening of a large number of ligands against a receptor. The following sections describe how to do this using the command line. For possible ways of doing this with the Python API, see :ref:`docking_python`. 
 
-Do not confuse this with multiple ligand docking (:ref:`docking_multiple_ligands`), in which multiple ligands are involved in a single docking run. 
+Do not confuse this with multiple ligand docking (:ref:`docking_multiple_ligands`), in which multiple ligands are docked simultaneously. 
 
 Command line options
 --------------------
 
-The command line usage is similar to the one for a single ligand. The only difference is that instead of specifying a single ligand using the ``--ligand`` option, we may use the ``--batch`` option for one or multiple times to include all ligands. 
+The command line usage is similar to the one for a single ligand. The only difference is that instead of specifying a single ligand using the ``--ligand`` option, we use the ``--batch`` option once or multiple times to include all ligands. 
 
-To specify the output directory, ``--dir`` may be used. The output filename will be ``<ligand_name>_out.pdbqt`` under the specified directory, where ``<ligand_name>`` is the name of the input ligand file without the path. When the name of the ligand is duplicated, an index will be added to the name to avoid the name collision. 
+Use ``--dir`` to specify the output directory. The output filename will be ``<ligand_name>_out.pdbqt`` under the specified directory, where ``<ligand_name>`` is the name of the input ligand file without the path. When the name of the ligand is duplicated, an index will be added to the name to avoid the name collision. 
 
 Assuming we have multiple ligand PDBQT files in the directory named ``ligands`` in the current path. For Linux and macOS, the command line would look like this: 
 

--- a/docs/source/docking_multiple_ligands.rst
+++ b/docs/source/docking_multiple_ligands.rst
@@ -12,7 +12,7 @@ System and software requirements
 
 This is a command-line tutorial for a flexible docking experiment with AutoDock-Vina. It can be done on macOS, Linux, and Windows Subsystem for Linux (WSL). 
 
-This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io/en/release-doc>`_.
+This tutorial uses python package **Meeko for receptor and ligand preparation**. Installation guide and advanced usage can be found from the `Meeko documentation <https://meeko.readthedocs.io>`_.
 
 The **input and expected output files** can be found here on `GitHub <https://github.com/ccsb-scripps/AutoDock-Vina/tree/develop/example/mulitple_ligands_docking>`_.
 

--- a/docs/source/docking_requirements.rst
+++ b/docs/source/docking_requirements.rst
@@ -8,7 +8,7 @@ In addition to AutoDockTools, the long standing GUI for docking calculation setu
 Python package Meeko
 -----
 
-The Python package `meeko <https://meeko.readthedocs.io/en/release-doc/>`_ is package recently developped in the Forli lab also at the `Center for Computational Structural Biology (CCSB) <https://ccsb.scripps.edu>`_. As showcased in the Colab examples, `Meeko <https://github.com/forlilab/Meeko>`_ provides commandline scripts for ligand preparation, receptor preparation and other essential tools for the following docking protocols:
+The Python package `meeko <https://meeko.readthedocs.io>`_ is package recently developped in the Forli lab also at the `Center for Computational Structural Biology (CCSB) <https://ccsb.scripps.edu>`_. As showcased in the Colab examples, `Meeko <https://github.com/forlilab/Meeko>`_ provides commandline scripts for ligand preparation, receptor preparation and other essential tools for the following docking protocols:
 
     - Docking with flexible macrocycles
     - Flexible docking
@@ -44,14 +44,18 @@ Type the following command to install ``Meeko`` and (optionally) ``ProDy``:
     
     $ conda activate vina
     $ conda install python=3.10    # for ProDy interoperability
-    $ conda install -c conda-forge numpy scipy rdkit vina meeko gemmi
+    $ conda install -c conda-forge numpy scipy rdkit vina meeko gemmi autogrid
     $ pip install prody
 
 AutoGrid4
 --------
 Git Repository: `CCSB-Scripps AutoGrid <https://github.com/ccsb-scripps/AutoGrid>`_
 
-See instruction in the repository's ``README`` to build the latest version of autogrid4. 
+.. code-block:: bash
+
+    $ conda install -c conda-forge autogrid 
+
+Alternatively, see instruction in the repository's ``README`` to build the latest version of autogrid4. 
 
 ADFR software suite
 -------------------


### PR DESCRIPTION
- remove branch from links to meeko readthedocs. Then it lands on the default, which is currently `release-doc`. If we ever want to change the default branch from `release-doc` to something else, we simply change it on the readthedocs server and don't need to update all links again.
- some text edits
- add autogrid conda install instructions
